### PR TITLE
Add option to update content as minor edit and include edit message

### DIFF
--- a/confluence/client.py
+++ b/confluence/client.py
@@ -212,8 +212,9 @@ class Confluence:
         return self._post_return_single(Content, 'content', {}, data, expand)
 
     def update_content(self, content_id, content_type, new_version,
-                       new_content, new_title, status=None, new_parent=None, new_status=None):
-        # type: (int, ContentType, int, str, str, Optional[ContentStatus], Optional[int], Optional[ContentStatus]) -> Content
+                       new_content, new_title, status=None, new_parent=None, new_status=None,
+                       minor_edit=False, edit_message=None):
+        # type: (int, ContentType, int, str, str, Optional[ContentStatus], Optional[int], Optional[ContentStatus], Optional[bool], Optional[str]) -> Content
         """
         Replace a piece of content in confluence. This can be used to update
         title, content, parent or status.
@@ -226,13 +227,17 @@ class Confluence:
         :param new_title: The new title.
         :param new_parent: The new parent content id, optional.
         :param new_status: The new content status, optional.
+        :param minor_edit: Defaults to False. Set to true to make this update
+            a minor edit.
+        :param edit_message: Edit message, optional.
 
         :return: The updated content object.
         """
         content = {
             'title': new_title,
             'version': {
-                'number': new_version
+                'number': new_version,
+                'minorEdit': minor_edit
             },
             'type': content_type.value,
             'body': {
@@ -242,6 +247,9 @@ class Confluence:
                 }
             }
         }
+
+        if edit_message:
+            content['version']['message'] = edit_message
 
         if new_parent:
             content['ancestors'] = [{


### PR DESCRIPTION
Hey there. I've added a couple minor options to `update_content`. The ability to specify the update as a minor edit `minor_edit=True`, as well as optionally including a message about the version change, e.g. `edit_message='Updated at ...'`.

I've tested this with our instance and it (thankfully) doesn't notify anyone on update, and naturally the message is included as well.

<img width="956" alt="screen shot 2018-04-25 at 1 46 42 pm" src="https://user-images.githubusercontent.com/1740742/39263056-200477fc-488f-11e8-8284-7254e671bcde.png">

Also, thanks a bunch for this library, it's been saving me quite a bit of time.