### PR TITLE
Handle page attachment updates gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml
+.idea/codeStyles
+.idea/dbnavigator.xml
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/confluence/client.py
+++ b/confluence/client.py
@@ -493,22 +493,7 @@ class Confluence:
         if not file_name:
             file_name = os.path.basename(file_path)
 
-        attachments = self.get_attachments(content_id, filename=file_name)
-
-        # Attachment items
-        attachment_items = list()
-
-        for item in attachments:
-            attachment_items.append(item)
-
-        # If attachment exist, create a new version of the file, otherwise create new
-        if attachment_items:
-            # Use just the last item ID from attachment_items,
-            # there should be only one attachment by that name anyway
-            uri = 'content/{}/child/attachment/{}/data'.format(content_id, attachment_items[-1].id)
-        else:
-            print("Attachment does not exist")
-            uri = 'content/{}/child/attachment'.format(content_id)
+        uri = 'content/{}/child/attachment'.format(content_id)
 
         with open(file_path, 'rb') as f:
             file = {


### PR DESCRIPTION
If file already exists, we want to update it, thus add a new version of it.
To update it, we need an ID and use it in API request.

This change will check if a file name exists, if yes, gets its ID and uses it to update attachment.
If not, just creates a new attachment.

Tested against Confluence 6.2.3