### PR TITLE
Add update_attachment and update_attachment_data

### DIFF
--- a/confluence/client.py
+++ b/confluence/client.py
@@ -138,9 +138,9 @@ class Confluence:
 
         return response
 
-    def _post_return_single(self, item_type, path, params, data, expand=None):
-        # type: (Callable, str, Dict[str, str], Any, Optional[List[str]]) -> Any
-        return item_type(self._post(path, params, data, files=None, expand=expand).json())
+    def _post_return_single(self, item_type, path, params, data, files=None, expand=None):
+        # type: (Callable, str, Dict[str, str], Any, Optional[Dict[str, Any]], Optional[List[str]]) -> Any
+        return item_type(self._post(path, params, data, files=files, expand=expand).json())
 
     def _post_return_multiple(self, item_type, path, params, data, files, expand=None):
         # type: (Callable, str, Dict[str, str], Any, Dict[str, Any], Optional[List[str]]) -> Any
@@ -219,7 +219,7 @@ class Confluence:
                 'id': parent_content_id
             }]
 
-        return self._post_return_single(Content, 'content', {}, data, expand)
+        return self._post_return_single(Content, 'content', {}, data, expand=expand)
 
     def update_content(self,
                        content_id,  # type: int
@@ -571,6 +571,49 @@ class Confluence:
 
         path = 'content/{}/child/attachment/{}'.format(page_id, attachment_id)
         return self._put_return_single(Content, path, {}, data=content, expand=expand)
+
+    def update_attachment_data(self,
+                               page_id,  # type; int
+                               attachment_id,  # type: int
+                               new_version,  # type: int
+                               file_path,  # type: str
+                               file_name=None,  # type: Optional[str]
+                               minor_edit=False,  # type: Optional[bool]
+                               expand=None  # type: Optional[List[str]]
+                               ):  # type: (...) -> Content
+        """
+        Updates an attachments contents to a new file.
+
+        :param page_id: The parent page of the attachment.
+        :param attachment_id: the confluence content to add the attachment to.
+        :param new_version: The new version number of the attachmnet. it must be current_version+1
+        :param file_path: The full location of the file on the local system.
+        :param file_name: Optionally the name to give the attachment in confluence.
+        :param status: Optionally the status of the attachment after upload.
+            Must be one of current or draft, defaults to current.
+        :param minor_edit: Defaults to False. Set to true to make this update
+            a minor edit.
+        :param expand: An optional list of properties to be expanded on the resulting attachment object.
+
+        :return: A Content object containing details of the attachment.
+        """
+        if not file_name:
+            file_name = os.path.basename(file_path)
+
+        files = {}  # type: Dict[str, Any]
+
+        if minor_edit:
+            files['minorEdit'] = 'true'
+
+        with open(file_path, 'rb') as f:
+            files['file'] = (file_name, f)
+
+            return self._post_return_single(Content,
+                                            'content/{}/child/attachment/{}/data'.format(page_id, attachment_id),
+                                            params={},
+                                            data={},
+                                            files=files,
+                                            expand=expand)
 
     def get_labels(self, content_id, prefix=None):  # type: (int, Optional[LabelPrefix]) -> Iterable[Label]
         """

--- a/confluence/client.py
+++ b/confluence/client.py
@@ -515,6 +515,63 @@ class Confluence:
                                               files={'file': (file_name, f)},
                                               data={})
 
+    def update_attachment(self,
+                          page_id,  # type: int
+                          attachment_id,  # type: str
+                          version,  # type: int
+                          filename,  # type: str
+                          new_comment=None,  # type: Optional[str]
+                          new_media_type=None,  # type: Optional[str]
+                          new_page_id=None,  # type: Optional[int]
+                          new_status=None,  # type: Optional[ContentStatus]
+                          expand=None,  # type: Optional[List[str]]
+                          ):  # type: (...) -> Content
+        """
+        Update the information about an attachment in confluence.
+        This can be used to update filename, media type, comment
+        or status.
+
+        :param page_id: The parent page of the attachment.
+        :param attachment_id: Id of attachment to be updated
+        :param version: This should be the current version.
+        :param filename: The filename to be used.
+        :param new_comment: The new comment to be used, optional.
+        :param new_media_type: The new comment to be used, optional.
+        :param new_page_id: The new page id for this attachment, optional.
+        :param new_status: The new content status, optional.
+        :param expand: An optional list of properties to be expanded on the resulting attachment object.
+
+        :return: The updated attachment object.
+        """
+        
+        content = {
+            'id': attachment_id,
+            'type': ContentType.ATTACHMENT.value,
+            'title': filename,
+            'status': 'current',
+            'version': {
+                'number': version,
+            },
+            'container': {},
+            'metadata': {}
+        }
+
+        if new_comment:
+            content['metadata']['comment'] = new_comment
+
+        if new_media_type:
+            content['metadata']['mediaType'] = new_media_type
+
+        if new_page_id:
+            content['container']['id'] = new_page_id
+            content['container']['type'] = ContentType.ATTACHMENT.value
+
+        if new_status:
+            content['status'] = new_status.value
+
+        path = 'content/{}/child/attachment/{}'.format(page_id, attachment_id)
+        return self._put_return_single(Content, path, {}, data=content, expand=expand)
+
     def get_labels(self, content_id, prefix=None):  # type: (int, Optional[LabelPrefix]) -> Iterable[Label]
         """
         Retrieve the set of labels on a piece of content.

--- a/confluence/client.py
+++ b/confluence/client.py
@@ -543,7 +543,6 @@ class Confluence:
 
         :return: The updated attachment object.
         """
-        
         content = {
             'id': attachment_id,
             'type': ContentType.ATTACHMENT.value,

--- a/confluence/client.py
+++ b/confluence/client.py
@@ -517,9 +517,9 @@ class Confluence:
 
     def update_attachment(self,
                           page_id,  # type: int
-                          attachment_id,  # type: str
+                          attachment_id,  # type: int
                           version,  # type: int
-                          filename,  # type: str
+                          new_filename=None,  # type: Optional[str]
                           new_comment=None,  # type: Optional[str]
                           new_media_type=None,  # type: Optional[str]
                           new_page_id=None,  # type: Optional[int]
@@ -534,7 +534,7 @@ class Confluence:
         :param page_id: The parent page of the attachment.
         :param attachment_id: Id of attachment to be updated
         :param version: This should be the current version.
-        :param filename: The filename to be used.
+        :param new_filename: The new filename to be used.
         :param new_comment: The new comment to be used, optional.
         :param new_media_type: The new comment to be used, optional.
         :param new_page_id: The new page id for this attachment, optional.
@@ -546,14 +546,14 @@ class Confluence:
         content = {
             'id': attachment_id,
             'type': ContentType.ATTACHMENT.value,
-            'title': filename,
-            'status': 'current',
             'version': {
                 'number': version,
             },
-            'container': {},
             'metadata': {}
         }
+
+        if new_filename:
+            content['title'] = new_filename
 
         if new_comment:
             content['metadata']['comment'] = new_comment
@@ -562,6 +562,7 @@ class Confluence:
             content['metadata']['mediaType'] = new_media_type
 
         if new_page_id:
+            content['container'] = {}
             content['container']['id'] = new_page_id
             content['container']['type'] = ContentType.ATTACHMENT.value
 

--- a/confluence/models/content.py
+++ b/confluence/models/content.py
@@ -60,7 +60,12 @@ class Content:
     """
 
     def __init__(self, json):  # type: (Dict[str, Any]) -> None
-        self.id = json['id']  # type: int
+        # attachment id get returned starting with att which can be stripped
+        # this ensures ids are always of type int
+        id = str(json['id'])
+        if id.startswith('att'):
+            id = id[3:]
+        self.id = int(id)
         self.title = json['title']  # type: str
         self.status = ContentStatus(json['status'])  # type: ContentStatus
         self.type = ContentType(json['type'])  # type: ContentType

--- a/endpoints.md
+++ b/endpoints.md
@@ -54,8 +54,8 @@ objects have not yet been expanded.
 |-----------|--------------------------------------------------------:|-------|
 |GET        |/rest/content/{id}/child/attachment                      | 1     |
 |POST       |/rest/content/{id}/child/attachment                      | 1     |
-|PUT        |/rest/content/{id}/child/attachment/{attachmentId}       |       |
-|POST       |/rest/content/{id}/child/attachment/{attachmentId}/data  |       |
+|PUT        |/rest/content/{id}/child/attachment/{attachmentId}       | 1     |
+|POST       |/rest/content/{id}/child/attachment/{attachmentId}/data  | 1     |
 
 ### content/{id}/descendant
 

--- a/integration_tests/test_attachment_operations.py
+++ b/integration_tests/test_attachment_operations.py
@@ -65,3 +65,17 @@ def test_download_attachment(tmpdir):  # type: (py.path.local) -> None
         assert file_contents == b"test"
     finally:
         c.delete_content(page_id, ContentStatus.CURRENT)
+
+
+def test_update_attachment(tmpdir):  # type: (py.path.local) -> None
+    page_id = c.create_content(ContentType.PAGE, space_key=space_key, content='', title='Test Update Attachment Page').id
+
+    try:
+        p = tmpdir.mkdir("attachments").join("test.txt")
+        p.write("test")
+        attachments = list(c.add_attachment(page_id, p.realpath()))
+        attachment = c.update_attachment(page_id, attachment[0].id, attachment[0].version.number, 'test_update.txt', new_media_type='text/plain')
+        assert attachment.title == 'test_update.txt'
+        assert attachment.metadata['mediaType'] == 'text/plain'
+    finally:
+        c.delete_content(page_id, ContentStatus.CURRENT)

--- a/integration_tests/test_attachment_operations.py
+++ b/integration_tests/test_attachment_operations.py
@@ -74,7 +74,7 @@ def test_update_attachment(tmpdir):  # type: (py.path.local) -> None
         p = tmpdir.mkdir("attachments").join("test.txt")
         p.write("test")
         attachments = list(c.add_attachment(page_id, p.realpath()))
-        attachment = c.update_attachment(page_id, attachment[0].id, attachment[0].version.number, 'test_update.txt', new_media_type='text/plain')
+        attachment = c.update_attachment(page_id, attachments[0].id, attachments[0].version.number, new_filename='test_update.txt', new_media_type='text/plain')
         assert attachment.title == 'test_update.txt'
         assert attachment.metadata['mediaType'] == 'text/plain'
     finally:

--- a/integration_tests/test_attachment_operations.py
+++ b/integration_tests/test_attachment_operations.py
@@ -81,6 +81,25 @@ def test_update_attachment(tmpdir):  # type: (py.path.local) -> None
         c.delete_content(page_id, ContentStatus.CURRENT)
 
 
+def test_update_attachment_move(tmpdir):  # type: (py.path.local) -> None
+    page_id_old = c.create_content(ContentType.PAGE, space_key=space_key, content='', title='Test Update Attachment From Page').id
+    page_id_new = c.create_content(ContentType.PAGE, space_key=space_key, content='', title='Test Update Attachment To Page').id
+
+    try:
+        p = tmpdir.mkdir("attachments").join("test.txt")
+        p.write("test")
+        attachments = list(c.add_attachment(page_id_old, p.realpath()))
+        _ = c.update_attachment(page_id_old, attachments[0].id, attachments[0].version.number, new_page_id=page_id_new)
+        attachments_old = list(c.get_attachments(page_id_old, filename='test.txt'))
+        attachments_new = list(c.get_attachments(page_id_new, filename='test.txt'))
+        assert len(attachments_old) == 0
+        assert len(attachments_new) == 1
+
+    finally:
+        c.delete_content(page_id_old, ContentStatus.CURRENT)
+        c.delete_content(page_id_new, ContentStatus.CURRENT)
+
+
 def test_update_attachment_data(tmpdir):  # type: (py.path.local) -> None
     page_id = c.create_content(ContentType.PAGE, space_key=space_key, content='', title='Test Update Attachment Page').id
 

--- a/integration_tests/test_attachment_operations.py
+++ b/integration_tests/test_attachment_operations.py
@@ -79,3 +79,20 @@ def test_update_attachment(tmpdir):  # type: (py.path.local) -> None
         assert attachment.metadata['mediaType'] == 'text/plain'
     finally:
         c.delete_content(page_id, ContentStatus.CURRENT)
+
+
+def test_update_attachment_data(tmpdir):  # type: (py.path.local) -> None
+    page_id = c.create_content(ContentType.PAGE, space_key=space_key, content='', title='Test Update Attachment Page').id
+
+    try:
+        p = tmpdir.mkdir("attachments").join("test.txt")
+        p.write("test")
+        attachments = list(c.add_attachment(page_id, p.realpath()))
+        p2 = tmpdir.join("attachments", "test2.txt")
+        p2.write("test2")
+        attachment = c.update_attachment_data(page_id, attachments[0].id, attachments[0].version.number + 1, p2.realpath())
+        assert attachment.title == 'test2.txt'
+        assert attachment.id == attachments[0].id
+        assert attachment.version.number == attachments[0].version.number + 1
+    finally:
+        c.delete_content(page_id, ContentStatus.CURRENT)

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -30,4 +30,4 @@ def test_create_group_with_valid_json():
             "download": "/download/attachment/123454/Puppet%20Architecture.png"
         }
     })
-    assert str(a) == 'att35459744 - Puppet Architecture.png'
+    assert str(a) == '35459744 - Puppet Architecture.png'


### PR DESCRIPTION
Aware that this overlaps with another older pull request #10.

This one just adds a thin layer over the REST API as I think you suggested in your comments on that one.

Still to add:
Support for update_attachment_data for changing the file contents.

Just wanted your thoughts on if this is the right approach.

Note changes to content.py to keep mypy happy with the odd attachment ids that confluence returns
