### PR TITLE
Add support for getting content ancestors

### DIFF
--- a/confluence/models/content.py
+++ b/confluence/models/content.py
@@ -90,6 +90,9 @@ class Content:
         if 'version' in json:
             self.version = Version(json['version'])
 
+        if 'ancestors' in json:
+            self.ancestors = [int(ancestor['id']) for ancestor in json['ancestors']]
+
         if self.type == ContentType.ATTACHMENT:
             self.links = json['_links']  # type: Dict[str, Any]
 

--- a/integration_tests/test_content_operations.py
+++ b/integration_tests/test_content_operations.py
@@ -146,3 +146,18 @@ def test_create_page_in_nonexistent_space():
 def test_get_content_with_bad_content_type():
     with pytest.raises(ValueError):
         c.get_content(ContentType.ATTACHMENT)
+
+def test_ancestors():
+    # Create test parent page
+    title = 'A Parent Page'
+    content = 'This is a full piece of content'
+    parent = c.create_content(ContentType.PAGE, title, space_key, content=content, expand=[])
+
+    # Create test child page
+    title = 'A Child Page'
+    content = 'This is another full piece of content'
+    child = c.create_content(ContentType.PAGE, title, space_key, content=content, parent_content_id=parent.id, expand=['ancestors'])
+    assert child.ancestors[-1] == parent.id
+
+    c.delete_content(parent.id, ContentStatus.CURRENT)
+    c.delete_content(child.id, ContentStatus.CURRENT)


### PR DESCRIPTION
Quite a simple addition that allows the anecestor list to be provided as a list of content ids.